### PR TITLE
Publish MPS 2022.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![artifacts.itemis.cloud](https://img.shields.io/badge/dynamic/xml?url=https://artifacts.itemis.cloud/repository/maven-mps/com/jetbrains/mps/maven-metadata.xml&label=artifacts.itemis.cloud&color=success&query=.//versioning/latest)](https://artifacts.itemis.cloud/#browse/browse:maven-mps:com%2Fjetbrains)
 [![Github pages](https://img.shields.io/badge/Github-pages-success)](https://github.com/orgs/mbeddr/packages?repo_name=build.publish.mps)
-[![projects.itemis.de](https://img.shields.io/badge/dynamic/xml?url=https://projects.itemis.de/nexus/content/repositories/mbeddr/com/jetbrains/mps/maven-metadata.xml&label=projects.itemis.de&color=inactive&query=.//versioning/latest)](https://projects.itemis.de/nexus/#nexus-search;quick~com.jetbrains)
 
 This repository contains a gradle script for publishing MPS and its jars to a few Maven repositories. You can use these dependencies, for example, in a Gradle or maven build script.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ The following artifacts are published:
 - *com.jetbrains.mps-modelchecker*
 - *com.jetbrains.mps-httpsupport-runtime*
 - *com.jetbrains.mps-project-check*
-- *com.jetbrains.platform-api*
 - *com.jetbrains.mps-workbench*
 - *com.jetbrains.annotations*
 
-**Note**: Since 2021.1, the artifact *com.jetbrains.platform-concurrency* is no longer available.
+**Notes**:
+- Since 2021.1, the artifact *com.jetbrains.platform-concurrency* is no longer available.
+- Since 2022.2, the artifact *com.jetbrains.platform-api* is no longer available.
 

--- a/build.gradle
+++ b/build.gradle
@@ -224,10 +224,12 @@ task packageMpsProjectCheckSources(type: Jar, dependsOn: unzipMPS) {
     }
 }
 
+/*
 task packagePlatformApi(type: Jar, dependsOn: unzipMPS) {
     baseName 'platform-api'
     from zipTree("$mpsUnpackedDir/lib/platform-api.jar")
 }
+ */
 
 
 task packageAnnotations(type: Jar, dependsOn: unzipMPS) {
@@ -386,12 +388,14 @@ publishing {
             artifact packageMpsProjectCheck
             artifact packageMpsProjectCheckSources
         }
+        /*
         platformApi(MavenPublication) {
             groupId 'com.jetbrains'
             artifactId 'platform-api'
             version mpsBuild
             artifact packagePlatformApi
         }
+         */
         mpsWorkbench(MavenPublication) {
             groupId 'com.jetbrains'
             artifactId 'mps-workbench'

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 
 import de.undercouch.gradle.tasks.download.Download
 
-ext.mpsMajor = '2021.3'
-ext.mpsBuild = '2021.3.2'
+ext.mpsMajor = '2022.2'
+ext.mpsBuild = '2022.2'
 
 def mpsDownloadDir = new File(project.buildDir, "MPS-${mpsBuild}")
 def mpsDownloadFile = new File(mpsDownloadDir, "MPS-${mpsBuild}.zip")


### PR DESCRIPTION
I've excluded platform-api as it doesn't exist in 2022.2 anymore.