### PR TITLE
Update gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test-packaging
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/mps/*')
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ jobs:
   test-packaging:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -21,9 +21,9 @@ jobs:
     needs: test-packaging
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'adopt'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,17 +3,23 @@
 
 name: Java CI with Gradle
 
-on:
-  push:
-    branches:
-      # Only on push events on master and mps branches
-      - master
-      - mps/*
+on: [push]
 jobs:
-  build:
-
+  test-packaging:
     runs-on: ubuntu-latest
-
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Test packaging
+        run: ./gradlew testPackaging
+  publish:
+    runs-on: ubuntu-latest
+    needs: test-packaging
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
@@ -23,8 +29,6 @@ jobs:
         distribution: 'adopt'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Test packaging
-      run: ./gradlew testPackaging
     - name: Publish to Github Packages
       run: ./gradlew publishAllPublicationsToGitHubPackagesRepository -Pgpr.user=${{github.actor}} -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: test-packaging
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/mps/*')
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/mps/')
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,6 +23,8 @@ jobs:
         distribution: 'adopt'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Test packaging
+      run: ./gradlew testPackaging
     - name: Publish to Github Packages
       run: ./gradlew publishAllPublicationsToGitHubPackagesRepository -Pgpr.user=${{github.actor}} -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
       

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,7 +5,10 @@ name: Java CI with Gradle
 
 on:
   push:
-
+    branches:
+      # Only on push events on master and mps branches
+      - master
+      - mps/*
 jobs:
   build:
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,15 @@ def mpsDownloadFile = new File(mpsDownloadDir, "MPS-${mpsBuild}.zip")
 def eapSuffix = (mpsBuild.contains("EAP")) ? " EAP" : ""
 def mpsUnpackedDir = new File(mpsDownloadDir, "MPS ${mpsMajor}${eapSuffix}")
 
+task testPackaging{
+    description "Task triggering all packaging tasks"
+}
+
+testPackaging.dependsOn {
+    tasks.withType(Jar).findAll {jarTask -> jarTask.name.startsWith('package')}
+}
+
+
 // Downloads MPS from jetbrains.com into ${mpsDownloadFile}
 task downloadMPS(type: Download) {
     doFirst {


### PR DESCRIPTION
This PRs updates our github actions and adds a new steps.

**test-packaging step**
- will perform a dry-run of all packing tasks in the project
- this will help us finding out if the directory layout is still valid for newer mps versions and prohibits a 1/2 broken publication

**publish step**
- has now a dependency on test-packaging 
- publication will only run when test-packaging was successfull
- we also make use of [step-if conditions](https://docs.github.com/en/actions/learn-github-actions/expressions#example-expression-in-an-if-conditional) to allow the publication only on `master` and` mps/* `branches
