### PR TITLE
actions: updated to newest node version 20

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ jobs:
   test-packaging:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -21,9 +21,9 @@ jobs:
     needs: test-packaging
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/mps/')
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '11'
         distribution: 'adopt'


### PR DESCRIPTION
We should update to the newes node version 20. See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/