### PR TITLE
Strip the root directory of MPS zip instead of trying to guess it

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,4 +16,4 @@ jobs:
           distribution: 'adopt'
       - name: Test packaging
         # Feel free to update the version as needed
-        run: ./gradlew testPackaging -PmpsVersion=2024.1
+        run: ./gradlew testPackaging -PmpsVersion=2025.1.1

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,6 @@ ext.mpsMajor = mpsMajorMatcher.group(1)
 
 def mpsUnzipDir = layout.buildDirectory.dir("MPS-${mpsVersion}").get().asFile
 def mpsDownloadFile = layout.buildDirectory.file("MPS-${mpsVersion}.zip")
-def eapSuffix = (mpsVersion.contains("EAP")) ? " EAP" : ""
-def mpsUnpackedDir = new File(mpsUnzipDir, "MPS ${mpsMajor}${eapSuffix}")
 
 task testPackaging{
     description "Task triggering all packaging tasks"
@@ -44,10 +42,16 @@ task downloadMPS(type: Download) {
 task unzipMPS(type: Sync, dependsOn: downloadMPS) {
     from(zipTree(mpsDownloadFile))
     into(mpsUnzipDir)
+    includeEmptyDirs = false
+
+    eachFile { fcd ->
+        // Strip zip root directory
+        fcd.relativePath = new RelativePath(true, fcd.relativePath.segments.drop(1))
+    }
 }
 
 task publishMPS(type: Zip, dependsOn: unzipMPS) {
-    from mpsUnpackedDir
+    from mpsUnzipDir
 }
 
 def additionalPomInfo = {
@@ -136,7 +140,7 @@ static String baseName(String file) {
     }
 }
 
-void createPublicationsFromMpsJars(Iterable<MpsJar> mpsJars, mpsUnpackedDir, additionalPomInfo) {
+void createPublicationsFromMpsJars(Iterable<MpsJar> mpsJars, mpsUnzipDir, additionalPomInfo) {
     mpsJars.each { mpsJar ->
         final jarBaseName = baseName(mpsJar.relativePath)
 
@@ -144,7 +148,7 @@ void createPublicationsFromMpsJars(Iterable<MpsJar> mpsJars, mpsUnpackedDir, add
             dependsOn(unzipMPS)
 
             archiveBaseName = jarBaseName
-            from zipTree("${mpsUnpackedDir}/${mpsJar.relativePath}")
+            from zipTree("${mpsUnzipDir}/${mpsJar.relativePath}")
         }
 
         TaskProvider<Jar> packageSourcesTask
@@ -159,7 +163,7 @@ void createPublicationsFromMpsJars(Iterable<MpsJar> mpsJars, mpsUnpackedDir, add
                 dependsOn(unzipMPS)
                 archiveBaseName = jarBaseName
                 archiveClassifier = 'sources'
-                from(zipTree("$mpsUnpackedDir/${mpsJar.relativeSourcesPath ?: 'lib/MPS-src.zip'}")) { CopySpec spec ->
+                from(zipTree("$mpsUnzipDir/${mpsJar.relativeSourcesPath ?: 'lib/MPS-src.zip'}")) { CopySpec spec ->
                     spec.include(mpsJar.sourceIncludes)
                 }
             }
@@ -284,4 +288,4 @@ mpsJars.configure {
     }
 }
 
-createPublicationsFromMpsJars(mpsJars, mpsUnpackedDir, additionalPomInfo)
+createPublicationsFromMpsJars(mpsJars, mpsUnzipDir, additionalPomInfo)


### PR DESCRIPTION
Test with MPS 2025.1.1 because it seems to have broken the usual rules.